### PR TITLE
feat(json): add treesitter highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ A comment block can be added at the bottom of your config file (for both QMK and
 **It must**
 
 - be a block comment to avoid extra comment symbols
-- be surrounded with`qmk:json:start` and end with `qmk:json:end`
+- be surrounded with `qmk:json:start` and end with `qmk:json:end`
 
 e.g.:
 
@@ -354,6 +354,14 @@ qmk:json:end
 */
 ```
 
+</details>
+
+<details>
+  <summary>Tree-sitter syntax highlighting for inline JSON</summary>
+
+`qmk.nvim` includes [`Tree-sitter` language injection query](https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting.html?highlight=injection#language-injection) that enables syntax highlighting for the inline JSON.
+If you have `Tree-sitter` enabled and `qmk.nvim` is loaded **before** `nvim-treesitter` (e.g. by setting `qmk.nvim` as a dependency for `nvim-treesitter`) it will be enabled automatically.
+Alternatively, you can copy the `queries/c/injections.scm` to your nvim config (e.g. `~/.config/nvim/after/queries/c/injections.scm`).
 </details>
 
 ## Layout

--- a/queries/c/injections.scm
+++ b/queries/c/injections.scm
@@ -1,0 +1,8 @@
+; extends
+
+((comment)+ @injection.content
+  (#match? @injection.content "qmk:json:start")
+  (#match? @injection.content "qmk:json:end")
+  (#offset! @injection.content 2 0 -1 0) ; rm header and footer
+  (#set! injection.language "json")
+)


### PR DESCRIPTION
Injecting JSON syntax highlighting to the inline JSON config makes editing it much nicer. This doesn't add a dependency to Tree-sitter, it'll Just Work™ if Tree-sitter is enabled and the plugin isn't lazy loaded.