### PR TITLE
feat(overrides): auto-escape magic characters in keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,11 @@ For the configuration
             -- key codes are mapped literally against the entire key in your layout
             -- longer key codes are checked first, and these will replace the value displayed in the preview
             --
-            -- lua magic patterns must be escaped with `%`, sorry, I'll fix this one day
+            -- lua magic patterns used to need escaping with `%` but not anymore
+            -- old escaped patterns should still work thoug
             -- watch out for emojis as they are double width
 			['LSG%(KC_GRAVE%)'] = 'Next Window',
+			['LAG(KC_GRAVE)'] = 'Prev Window',
 		},
 	},
 }

--- a/lua/qmk/config/init_spec.lua
+++ b/lua/qmk/config/init_spec.lua
@@ -2,6 +2,7 @@ local E = require('qmk.errors')
 local match = assert.combinators.match
 local match_string = require('matcher_combinators.matchers.string')
 local config = require('qmk.config')
+local format = require('qmk.format.utils')
 
 local function none_missing(conf)
 	return vim.tbl_deep_extend('force', { name = 'test', layout = { 'x' } }, conf)
@@ -101,10 +102,8 @@ describe('config', function()
 			msg = 'invalid param',
 			input = none_missing({ auto_format_pattern = { '*keymap.c', 3 } }),
 			-- escape [] so that regex mathing works
-			err = string.gsub(
-				E.parse_invalid('', 'auto_format_pattern', 'string or string[]', 'table'),
-				'([%[%]])',
-				'%%%1'
+			err = format.escape_magic_characters(
+				E.parse_invalid('', 'auto_format_pattern', 'string or string[]', 'table')
 			),
 		}
 		it(test.msg, function()

--- a/lua/qmk/format/get_key_text.lua
+++ b/lua/qmk/format/get_key_text.lua
@@ -1,14 +1,17 @@
+local utils = require('qmk.format.utils')
+
 ---find all matching key codes from the key string and replace them with the keymap value
 ---@param keymap qmk.KeymapList
 ---@return fun (key : string): string
 local function get_key_text(keymap)
-	return function(key)
-		local str = key
+	return function(str)
 		for _, k in ipairs(keymap) do
+      -- escape lua magic characters in the matching pattern
+      local key, value = utils.escape_magic_characters(k.key), k.value
 			-- check if the key is a substring of the current key
-			if string.find(str, k.key) then
+			if string.find(str, key) then
 				-- replace the key with the override
-				str = string.gsub(str, k.key, k.value)
+				str = string.gsub(str, key, value)
 			end
 		end
 		return str

--- a/lua/qmk/format/keymap_spec.lua
+++ b/lua/qmk/format/keymap_spec.lua
@@ -444,6 +444,33 @@ describe('keymaps', function()
 				'            31 , 32 , 33 ,                 34 , 35 , 36',
 			},
 		},
+    --------------------------------------------------------------------------
+    -- with magic patterns preview
+    --------------------------------------------------------------------------
+    {
+      msg = 'keymaps with magic lua patterns, also respects escapes for back-compat',
+      input = {
+        options = testy.create_options_preview({
+          'x x x',
+        }, {
+          comment_preview = {
+            position = 'top',
+            keymap_overrides = {
+              ['LSG(A)'] = 'magic', -- magic characters are escaped
+              ['C%(KC_B%)'] = 'also magic', -- already escaped, so respected (back-compat)
+            },
+          },
+        }),
+        keys = { 'C(KC_B)', 'LSG(A)', 'KC_PERC' },
+      },
+      output = {
+        '//    ┌────────────┬───────┬───┐',
+        '//    │ also magic │ magic │ % │',
+        '//    └────────────┴───────┴───┘',
+        '[_FOO] = LAYOUT(',
+        '  C(KC_B) , LSG(A) , KC_PERC',
+      },
+    },
 	}
 
 	for _, test in pairs(tests) do

--- a/lua/qmk/format/utils.lua
+++ b/lua/qmk/format/utils.lua
@@ -3,8 +3,18 @@ local M = {}
 ---@param line string
 ---@return string
 function M.remove_trailing_space(line)
-	local trimed = line:gsub(' +$', '')
-	return trimed
+	local trimmed = line:gsub(' +$', '')
+	return trimmed
+end
+
+---@param line string
+---@return string
+function M.escape_magic_characters(line)
+	-- Escape magic characters, but skip ones that are already escaped (backwards compatibility)
+	local escaped = line:gsub('(%%?)([().%%+%-%*%?%[%]%^%$])', function(escape, char)
+		return escape == '%' and escape .. char or '%' .. char
+	end)
+  return escaped
 end
 
 return M

--- a/test/fixtures/zmk/dactyl_inline.keymap
+++ b/test/fixtures/zmk/dactyl_inline.keymap
@@ -58,7 +58,7 @@ qmk:json:start
 {
   "comment_preview": {
     "keymap_overrides": {
-      "&mt LC%(LG%(LS%(LALT%)%)%) ESC": "HYPER ESC",
+      "&mt LC(LG(LS(LALT))) ESC": "HYPER ESC",
       "&mt LCMD GRAVE": "CYCLE WIN"
     }
   }

--- a/test/fixtures/zmk/dactyl_inline_out.keymap
+++ b/test/fixtures/zmk/dactyl_inline_out.keymap
@@ -83,7 +83,7 @@ qmk:json:start
 {
   "comment_preview": {
     "keymap_overrides": {
-      "&mt LC%(LG%(LS%(LALT%)%)%) ESC": "HYPER ESC",
+      "&mt LC(LG(LS(LALT))) ESC": "HYPER ESC",
       "&mt LCMD GRAVE": "CYCLE WIN"
     }
   }


### PR DESCRIPTION
No more adding % before every () in the override definitions \o/ But
it's a breaking change since the old overrides stop working until they
are manually edited to not escape things manually. 